### PR TITLE
Error on oc_server.py import

### DIFF
--- a/oidc_example/op1/oc_server.py
+++ b/oidc_example/op1/oc_server.py
@@ -23,7 +23,7 @@ from oic.utils.authn.authn_context import AuthnBroker
 
 __author__ = 'rohe0002'
 
-Rmeoveimport re
+import re
 
 from logging.handlers import BufferingHandler
 


### PR DESCRIPTION
There was a typo on the import for re on the oidc_example/op1/oc_server.py file
