### PR TITLE
Use session_state to backup consumer state if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on the [KeepAChangeLog] project.
 [KeepAChangeLog]: https://keepachangelog.com/
 
 ## Unreleased
+
+- [#854] Improve OIDC Session Management support by using the `session_state` parameter from an *Authentication Response* (if available) as a key to store `Consumer` data.
+
 ### Changed
 - [#847] Using pydantic for settings instead of custom class
 - [#851], [#852] Add `authn_method` to `Consumer.complete`


### PR DESCRIPTION
This PR improves the support for [Open ID Connect session management](https://openid.net/specs/openid-connect-session-1_0.html).

When processing the *Authorization Response* from an *Authorization Server*, it allows library users to save the consumer data using the `session_state` parameter from the response.

This makes it easier to integrate this library in a webserver, as session keys are very usefull to find back the appropriate `Consumer` instance from the `SessionBackend`.

More details on the motivation behind this PR can be found in the following discussion : #853 


-----

* [x]  Any changes relevant to users are recorded in the `CHANGELOG.md`.
* [x]  The documentation has been updated, if necessary. 
* [x]  New code is annotated. 
* [x]  Changes are covered by tests.