### PR TITLE
Moved dependency from pydantic to pydantic-settings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,7 +87,7 @@ setup(
     install_requires=[
         "requests",
         "pycryptodomex",
-        "pydantic",
+        "pydantic-settings",
         "pyjwkest>=1.3.6",
         "mako",
         "cryptography",

--- a/src/oic/utils/settings.py
+++ b/src/oic/utils/settings.py
@@ -9,7 +9,7 @@ Settings for oic objects.
 In order to configure some objects in PyOIDC, you need a settings object.
 If you need to add some settings, make sure that you settings class inherits from the appropriate class in this module.
 
-The settings make use of `pydantic <https://docs.pydantic.dev/usage/settings/>`_ library.
+The settings make use of `pydantic-settings <https://docs.pydantic.dev/usage/settings/>`_ library.
 It is possible to instance them directly or use environment values to fill the settings.
 """
 from typing import Optional
@@ -17,7 +17,7 @@ from typing import Tuple
 from typing import Union
 
 import requests
-from pydantic import BaseSettings
+from pydantic_settings import BaseSettings
 
 
 class PyoidcSettings(BaseSettings):


### PR DESCRIPTION
`BaseSettings` have been moved to `pydantic-settings` package under the same maintainer. As Pyoidc is using `BaseSettings` only in `oic.utils.settings`, we can change the dependency without any problem.