### PR TITLE
Fix device flow authorization endpoint

### DIFF
--- a/src/oic/extension/device_flow.py
+++ b/src/oic/extension/device_flow.py
@@ -89,7 +89,11 @@ class DeviceFlowClient(SingleClient):
         if scope:
             req["scope"] = scope
 
-        http_response = self.host.http_request(self.host.provider_info["device_endpoint"], "POST", req.to_urlencoded())
+        http_response = self.host.http_request(
+            self.host.provider_info["device_authorization_endpoint"],
+            "POST",
+            req.to_urlencoded(),
+        )
 
         response = self.host.parse_request_response(AuthorizationResponse, http_response, "json")
 

--- a/src/oic/oic/__init__.py
+++ b/src/oic/oic/__init__.py
@@ -1172,9 +1172,7 @@ class Client(oauth2.Client):
     def store_registration_info(self, reginfo):
         self.registration_response = reginfo
         if "token_endpoint_auth_method" not in self.registration_response:
-            self.registration_response["token_endpoint_auth_method"] = (  # nosec
-                "client_secret_basic"
-            )
+            self.registration_response["token_endpoint_auth_method"] = "client_secret_basic"  # nosec
         self.client_id = reginfo["client_id"]
         try:
             self.client_secret = reginfo["client_secret"]


### PR DESCRIPTION
Device authorization endpoint is `device_authorization_endpoint` as per https://www.rfc-editor.org/rfc/rfc8628.html#section-4

- [ ] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [ ] Changes are covered by tests.
---
