### PR TITLE
Replace deprecated `datetime.utcnow()`

### DIFF
--- a/src/oic/utils/time_util.py
+++ b/src/oic/utils/time_util.py
@@ -17,7 +17,7 @@ import calendar
 import re
 import sys
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 from datetime import timedelta
 from typing import Dict
 
@@ -175,7 +175,7 @@ def time_in_a_while(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=0
     :return: UTC time
     """
     delta = timedelta(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return datetime.utcnow() + delta
+    return datetime.now(timezone.utc) + delta
 
 
 def time_a_while_ago(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=0, hours=0, weeks=0):
@@ -196,7 +196,7 @@ def time_a_while_ago(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=
     :return: datetime instance
     """
     delta = timedelta(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return datetime.utcnow() - delta
+    return datetime.now(timezone.utc) - delta
 
 
 def in_a_while(
@@ -350,7 +350,7 @@ def later_than(after, before):
 
 
 def utc_time_sans_frac():
-    return int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
+    return int(datetime.now(timezone.utc).timestamp())
 
 
 def time_sans_frac():
@@ -371,4 +371,4 @@ def epoch_in_a_while(days=0, seconds=0, microseconds=0, milliseconds=0, minutes=
     :return: Seconds since epoch (1970-01-01)
     """
     dt = time_in_a_while(days, seconds, microseconds, milliseconds, minutes, hours, weeks)
-    return int((dt - datetime(1970, 1, 1)).total_seconds())
+    return int(dt.timestamp())

--- a/tests/test_http_util.py
+++ b/tests/test_http_util.py
@@ -113,8 +113,10 @@ class TestCookieDealer(object):
         kaka = cookie_dealer.delete_cookie(cookie_name)
         cookie_expiration = kaka[1].split(";")[1].split("=")[1]
 
-        now = datetime.datetime.utcnow()  #
-        cookie_timestamp = datetime.datetime.strptime(cookie_expiration, "%a, %d-%b-%Y %H:%M:%S GMT")
+        now = datetime.datetime.now(datetime.timezone.utc)
+        cookie_timestamp = datetime.datetime.strptime(cookie_expiration, "%a, %d-%b-%Y %H:%M:%S GMT").astimezone(
+            datetime.timezone.utc
+        )
         assert cookie_timestamp < now
 
     def test_cookie_dealer_improperly_configured(self):

--- a/tests/test_oic_provider.py
+++ b/tests/test_oic_provider.py
@@ -1579,7 +1579,7 @@ class TestProvider(object):
 
         all_cookies.load(cookies_string)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         for c in [self.provider.cookie_name, self.provider.session_cookie_name]:
             dt = datetime.datetime.strptime(all_cookies[c]["expires"], "%a, %d-%b-%Y %H:%M:%S GMT")
             assert dt < now  # make sure the cookies have expired to be cleared

--- a/tests/test_time_util.py
+++ b/tests/test_time_util.py
@@ -1,6 +1,6 @@
 import calendar
 import time
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -193,8 +193,8 @@ def test_parse_duration_error(duration):
 
 
 def test_time_a_while_ago():
-    dt = datetime.utcnow()
-    t = time_a_while_ago(seconds=10)
+    dt = datetime.now(timezone.utc)
+    t = time_a_while_ago(seconds=10).astimezone(timezone.utc)
     delta = dt - t  # slightly less than 10
     assert (delta.seconds == 9 and delta.microseconds > 0) or delta.seconds == 10
 
@@ -208,7 +208,7 @@ def test_a_while_ago():
 
 
 def test_shift_time():
-    dt = datetime.utcnow()
+    dt = datetime.now(timezone.utc)
     t = shift_time(dt, 10)
     delta = t - dt  # exactly 10
     assert delta.seconds == 10
@@ -250,5 +250,5 @@ def test_later_than_str():
 
 def test_utc_time():
     utc_now = utc_time_sans_frac()
-    expected_utc_now = int((datetime.utcnow() - datetime(1970, 1, 1)).total_seconds())
+    expected_utc_now = int((datetime.now(timezone.utc) - datetime(1970, 1, 1, tzinfo=timezone.utc)).total_seconds())
     assert utc_now == expected_utc_now


### PR DESCRIPTION
`datetime.utcnow()` has been deprecated since Python 3.12. We replace it by creating timezone-aware datetime instances everywhere `utcnow()` was used.

---
- [ ] ~~Any changes relevant to users are recorded in the `CHANGELOG.md`.~~
- [ ] ~~The documentation has been updated, if necessary.~~
- [x] ~~New code is annotated.~~
- [x] Changes are covered by tests.

