### PR TITLE
Migrate to modern logger interface

### DIFF
--- a/src/oic/utils/userinfo/ldap_info.py
+++ b/src/oic/utils/userinfo/ldap_info.py
@@ -92,7 +92,7 @@ class UserInfoLDAP(UserInfo):
                     try:
                         attr = self.openid2ldap[key]
                     except KeyError:
-                        logger.warn("OIDC attribute '%s' not defined in map" % key)
+                        logger.warning("OIDC attribute '%s' not defined in map" % key)
                     else:
                         try:
                             avaspec[attr].append(val)


### PR DESCRIPTION
## Description
The `logger.warn()` method is deprecated since Python2.7 and replaced with `logger.warning()`. It leads to those warnings:
```python
DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```