### PR TITLE
fix: issue 893, used the wrong issuer for id_token_hint validation on…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ The format is based on the [KeepAChangeLog] project.
 
 ## Unreleased
 
+### Changed
 - [#896]: Add the `prompt` parameter to `oic.oic.Consumer.begin`
 
+### Fixed
+
+- [#897]: End Session endpoint verifies id token hint against incorrect issuer
+
 [#896]: https://github.com/CZ-NIC/pyoidc/pull/896
+[#897]: https://github.com/CZ-NIC/pyoidc/pull/897
 
 ## 1.7.0 [2024-04-25]
 ### Changed

--- a/src/oic/oic/provider.py
+++ b/src/oic/oic/provider.py
@@ -2070,7 +2070,7 @@ class Provider(AProvider):
                 args = {}
 
             try:
-                id_token_hint.verify(iss=self.baseurl, skew=far_away, nonce_storage_time=far_away, **args)
+                id_token_hint.verify(iss=self.name, skew=far_away, nonce_storage_time=far_away, **args)
             except (VerificationError, NotForMe) as err:
                 logger.warning("Verification error on id_token_hint: %s", err)
                 return error_response("invalid_request", "Bad Id Token hint")

--- a/tests/test_oic_provider_logout.py
+++ b/tests/test_oic_provider_logout.py
@@ -418,7 +418,7 @@ class TestProvider(object):
         id_token = self._auth_with_id_token()
         assert session_get(self.provider.sdb, "sub", id_token["sub"])
 
-        issuer_key = KEYJAR.keys_by_alg_and_usage(issuer=SERVER_INFO['issuer'], alg="RS256", usage="sig")
+        issuer_key = KEYJAR.keys_by_alg_and_usage(issuer=SERVER_INFO["issuer"], alg="RS256", usage="sig")
         id_token_hint = id_token.to_jwt(key=issuer_key, algorithm="RS256")
         resp = self.provider.end_session_endpoint(urlencode({"id_token_hint": id_token_hint}))
 


### PR DESCRIPTION
The provider.name should probably be called 'issuer', as thats what it ends up to be.
The baseurl is just the URL where the provider mounts and announces its endpoints, but does not have to match the issuer at all.

The tests were technically broken before, but the provider.baseurl = provider.name hack in the test setup hid the problem of an issuer mismatch.

- [x] Any changes relevant to users are recorded in the `CHANGELOG.md`.
- [ ] The documentation has been updated, if necessary.
- [ ] New code is annotated.
- [x] Changes are covered by tests.
---

Closes #893 